### PR TITLE
🤖 Bump actions/checkout v3 → v4

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run a one-line script
         run: echo Hello, ${{ github.event.inputs.name }}!
       - name: Run a multi-line script


### PR DESCRIPTION
🤖 AI-generated, review before forwarding externally. Trivial actionlint fix; if you reference this demo in any onboarding/dispatch material the v3 warning would show on first run.

actionlint output:
```
.github/workflows/basic.yml:16:15: the runner of "actions/checkout@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
```

Found via heartbeat actionlint sweep across austenstone/* demo repos. Hypothesis #47 verified (2/5 repos had silent bugs).