### PR TITLE
fix(ci): drop broken triggers on self-test workflow (1yr of red)

### DIFF
--- a/.github/workflows/usage.yaml
+++ b/.github/workflows/usage.yaml
@@ -1,9 +1,5 @@
 name: 📅 Schedule Workflow Dispatch
 on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       date:


### PR DESCRIPTION
## Problem

`usage.yaml` (the 📅 Schedule Workflow Dispatch self-test) has been failing on every push, PR, and `*/5 * * * *` cron tick for ~1 year — since 2025-06-17 — with:

```
Action failed: workflow input is required
Error: workflow input is required
    at getInputs (src/index.ts:33:1)
```

The job calls `./` with `workflow: ${{ inputs.workflow }}`, but `inputs.workflow` only exists on `workflow_dispatch`. Push, pull_request, and schedule events all evaluate it to empty → every run errors at startup.

Latest example: [run 27868131437](https://github.com/austenstone/schedule/actions/runs/27868131437) (2026-06-20 10:16Z).

## Fix

Remove `push:`, `pull_request:`, and `schedule: */5` triggers. Keep `workflow_dispatch` as the only meaningful entrypoint — it's the only mode where the required `workflow` and `date` inputs are guaranteed.

Net effect:
- Stops ~12 failed runs/hour (8,760+/yr) of notification noise
- No behavior change for the documented dispatch flow
- Only 4 lines removed

## Verify

After merge: `gh run list -R austenstone/schedule --workflow=usage.yaml --limit 3` should show no new runs unless dispatched manually.

🤖 AI-generated by heartbeat (low-risk: removes broken triggers, no logic change). Resolves hypothesis-52 in agent state.

---
*Heartbeat session: hb-2026-06-20-0637et*