### PR TITLE
fix(usage): default workflow input to basic.yml

### DIFF
--- a/.github/workflows/usage.yaml
+++ b/.github/workflows/usage.yaml
@@ -9,8 +9,8 @@ on:
         default: 'in 1 hour'
       workflow:
         description: 'Workflow to run at schedule time'
-        required: true
         type: choice
+        default: 'basic.yml'
         options:
           - 'basic.yml'
           - 'codeql.yml'


### PR DESCRIPTION
🤖 AI-generated by heartbeat 2026-06-21. Fixes austenstone-notes#405.

## Problem
`📅 Schedule Workflow Dispatch` (`usage.yaml`) failing on `schedule` event invocations because the `workflow` input is `required: true` with no default. GitHub appears to be firing the workflow on schedule events (possibly from a stale cron attached to a prior revision), and the action correctly rejects empty input.

## Fix (Option 1 from #405)
- Drop `required: true` on the `workflow` input
- Add `default: 'basic.yml'`

Smallest possible diff. Makes the self-test resilient to any invocation path (scheduled, dispatched, API).

## Verification
Mechanical 2-line change. Existing `date` input already has a default ('in 1 hour'), so this matches the established pattern.