### PR TITLE
chore: move to node24 runtime and harden workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     # eslint v9+ plugin majors (eslint-plugin-jest 29, eslint-plugin-github 6, @eslint/js 10,
     # @typescript-eslint/* 8+) require eslint v9 peer dep; this repo is on eslint v8.
     # Ignore plugin majors until an eslint v8→v9 coordinated upgrade. PRs #85/#87/#91/#93 closed.
+    # TypeScript 7 is the native Go port; its programmatic API isn't stable until 7.1, so
+    # ts-jest, ts-node-dev and typescript-eslint (peer `<6.1.0`) all break. PR #94 closed.
     ignore:
       - dependency-name: "@actions/core"
         update-types: ["version-update:semver-major"]
@@ -35,4 +37,6 @@ updates:
       - dependency-name: "@typescript-eslint/eslint-plugin"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript-eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,9 +8,13 @@ on:
         required: false
         default: 'Bob the Builder'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,30 @@ on:
     paths-ignore:
       - "**.md"
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run lint
-      - run: npm run build
       - run: npm test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm run build
+      # dist/ is what consumers execute, so a stale bundle silently ships old code.
+      - name: Verify dist/ is up to date
+        run: |
+          if ! git diff --quiet --exit-code dist/; then
+            echo "::error::dist/ is out of date. Run 'npm run build' and commit the result."
+            git diff --stat dist/
+            exit 1
+          fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,19 +4,34 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
 
       - run: npx npm-check-updates -u --target minor
       - run: npm i --legacy-peer-deps
       - run: npm audit fix || true
+
+      # This job commits straight to main, so gate it on the full suite.
+      # An unattended bad bump would otherwise ship a broken dist/ to consumers.
+      - run: npm run lint
+      - run: npm test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0

--- a/.github/workflows/usage.yaml
+++ b/.github/workflows/usage.yaml
@@ -18,10 +18,14 @@ concurrency:
   group: schedule${{ github.event.inputs.date }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   schedule:
     name: 📅 Schedule
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token

--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Why

Two things here: an urgent runtime deadline, and closing the hole that let [#99](https://github.com/austenstone/schedule/pull/99)'s bug ship in the first place.

### `node20` is on a hard deadline

`action.yml` declared `runs.using: "node20"`. Node 20 hit EOL in April 2026, GitHub-hosted runners [defaulted to Node 24 on 2026-06-16](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), and Node 20 is **fully removed in fall 2026** — at which point every action still pinned to `node20` hard-fails with no opt-out. `runs.using` currently accepts only `node20` and `node24`, so this is the one move available.

For reference, `actions/checkout@v5` and `stefanzweifel/git-auto-commit-action@v7.2.0` already ship `node24`.

### `update.yml` could ship a broken `dist/` unattended

This is the one that actually bothers me. `update.yml` runs nightly, bumps deps, and commits **straight to `main`** — but it only ran `npm run build` first. No lint, no tests. A bad transitive bump would be auto-committed and published to every consumer with nobody in the loop.

That's now gated on `npm run lint && npm test` before the build.

### CI never checked that `dist/` matched source

`dist/` is what consumers actually execute. A stale bundle silently ships old code and is the classic silent killer of a JS action. CI now rebuilds and fails if the committed bundle drifts:

```yaml
- name: Verify dist/ is up to date
  run: |
    if ! git diff --quiet --exit-code dist/; then
      echo "::error::dist/ is out of date. Run 'npm run build' and commit the result."
      git diff --stat dist/
      exit 1
    fi
```

Verified non-vacuous locally — appending a byte to `dist/index.js` fires the guard, and it goes clean again after `git checkout`.

## What changed

| File | Change |
|---|---|
| `action.yml` | `runs.using`: `node20` → `node24` |
| `ci.yml` | `permissions: contents: read`, `timeout-minutes: 10`, pinned `node-version: 24` + npm cache, `dist/` freshness gate |
| `update.yml` | gate auto-commit on lint + test, SHA-pin `git-auto-commit-action`, `timeout-minutes`, explicit `node-version` |
| `usage.yaml`, `basic.yml` | least-privilege `permissions:` + `timeout-minutes` |
| `dependabot.yml` | ignore `typescript` majors |

### On the SHA pin

`stefanzweifel/git-auto-commit-action@v7` → `@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0`. Verified against the API — it's a lightweight tag, so the tag SHA is the commit SHA:

```
$ gh api repos/stefanzweifel/git-auto-commit-action/git/ref/tags/v7.2.0
{"sha":"4a55954c782fc1ea30b9056cd3e7a2b40ca8887d","tag":"refs/tags/v7.2.0","type":"commit"}
```

This action has write access to `main` in `update.yml`, so a floating tag there is a real supply-chain surface.

### On the `typescript` ignore

`dependabot.yml` had ignores for `@actions/*` and the eslint plugin majors but **not** `typescript` — which is why [#94](https://github.com/austenstone/schedule/pull/94) (TS 7.0.2) had to be closed by hand. TypeScript 7 is the native Go port; its programmatic compiler API isn't stable until 7.1, so `ts-jest`, `ts-node-dev` and `typescript-eslint` all break. `typescript-eslint@8.67.0` explicitly caps its peer at `typescript: ">=4.8.4 <6.1.0"`. Added the ignore with the rationale inline so the next person doesn't re-litigate it.

## Verification

- `npm run lint` ✅
- `npm test` ✅ 15/15
- `npm run build` ✅, `dist/` clean
- All 5 workflow/config YAML files parse
- `dist/` guard proven to fire on drift and clear on restore
- Pinned SHA verified against the GitHub API

Live end-to-end verification on the `node24` runtime to follow on this branch.

## Deliberately not in scope

- **No cron on `usage.yaml`.** Without one, the polling path is never exercised automatically in this repo — but adding a schedule burns minutes and creates real dispatches, so that's the owner's call.
- **`@actions/core@3` / `@actions/github@9`.** Both are ESM-only with no `exports.require`, and ncc emits `require()` into ESM ([vercel/ncc#1163](https://github.com/vercel/ncc/issues/1163)). Unblocking them means swapping the bundler to esbuild — not something to do in the same pass as a runtime bump. Filing a follow-up.
