### PR TITLE
docs: point example at the floating v1 tag and fix inputs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,15 @@ concurrency:
   group: schedule${{ github.event.inputs.date }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   schedule:
     name: 📅 Schedule
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: austenstone/schedule@v1.3
+      - uses: austenstone/schedule@v1
         with:
           github-token: ${{ secrets.TOKEN }}
           date: ${{ github.event.inputs.date }}
@@ -95,6 +98,15 @@ jobs:
           timezone: 'US/Eastern' # US/Central, US/Pacific
           wait-ms: 45000
 ```
+
+The job needs no `GITHUB_TOKEN` permissions of its own because scheduling is done
+with the `TOKEN` secret, so `permissions: {}` is the correct least privilege here.
+
+#### Where schedules are stored
+
+Schedules live in repository variables named `_SCHEDULE_<workflow-id>_<timestamp>_<uuid>`.
+The action creates one when you schedule a workflow and deletes it once the run is
+dispatched, so nothing needs cleaning up by hand.
 
 #### Timezone
 
@@ -181,7 +193,7 @@ Various inputs are defined in [`action.yml`](action.yml):
 | owner | Optional repository owner to run the workflow on. | ${{ github.repository_owner }} |
 | repo | Optional repository name to run the workflow on. | ${{ github.repository }} |
 | timezone | Timezone to use for the schedule | US/Eastern |
-| inputs | Inputs to pass to the workflow |
+| inputs | Inputs to pass to the workflow | ${{ toJson(github.event.inputs) }} |
 | inputs-ignore | Inputs to ignore when passing to the workflow | date,workflow |
 
 <!-- 


### PR DESCRIPTION
## Why

The README's copy-paste example pinned `austenstone/schedule@v1.3` — **released May 2024**. There's no floating `v1` tag, so every consumer who followed the docs is running two-year-old code and gets nothing merged since, including the duplicate-schedule fix for #60 and the scheduling fix in #99.

Release hygiene is the actual root cause here (a `v1.4` + floating `v1` follows this PR), but the README is the thing pointing people at the stale pin.

## Changes

**Fixed a broken table row.** The `inputs` row was missing its default column entirely, so the cell count didn't match the header and it rendered ragged:

```diff
-| inputs | Inputs to pass to the workflow |
+| inputs | Inputs to pass to the workflow | ${{ toJson(github.event.inputs) }} |
```

I diffed the whole table against `action.yml` programmatically rather than by eye — all 11 inputs now agree on name, description, and default.

**`@v1.3` → `@v1`** in the example.

**`permissions: {}` + `timeout-minutes` in the example.** Scheduling is done with the `TOKEN` secret, so the job genuinely needs zero `GITHUB_TOKEN` scopes. Worth showing since people copy this verbatim.

**Documented the `_SCHEDULE_*` variables.** The action creates repository variables in your repo as its datastore. Line 5 alludes to it ("poll GitHub variables which are used as our database") but never says they'll show up in your repo settings or that they're cleaned up automatically. That's a surprise worth one paragraph.

## Verification

- The example YAML block is extracted from the README and parsed — it's valid, not just plausible-looking
- Inputs table diffed against `action.yml`: ✅ 11/11 match
- The `@v1` tag this now references is created immediately after merge

## Follow-up

Cutting `v1.4` and creating the floating `v1` right after this lands.
